### PR TITLE
Fix error: Can not read property device on undefined

### DIFF
--- a/app/lib/dynamicStore/enhance.js
+++ b/app/lib/dynamicStore/enhance.js
@@ -145,7 +145,7 @@ export const getWrapperComponent = (
     static async getInitialProps(...params) {
       const initialParams = params[0];
 
-      const { store, isServer, req, query, res, pathname, asPath } = initialParams;
+      const { store, isServer, req = {}, query, res = {}, pathname, asPath } = initialParams;
 
       injectSagaAndReducer(key, store, saga, reducer);
       store.dispatch(serverActions.setCurrentRoute(pathname));


### PR DESCRIPTION
As getInitialProps() does not provide req and res properties at client/browser. Adding empty object as default.

**Issue Screenshot:**
![image](https://user-images.githubusercontent.com/5174435/62609891-302f2980-b920-11e9-93e8-a6cea8d13ed0.png)

@rakeshmenon @vinodloha 