### PR TITLE
Fix error: Buildify css path issue on windows

### DIFF
--- a/app/next.config.js
+++ b/app/next.config.js
@@ -45,14 +45,15 @@ module.exports = withPlugins([withBundleAnalyzer, withOffline], {
       const foundation = {
         destPath: '.next/static/styles/vendor/',
         files: [
-          path.resolve(__dirname, '/node_modules/normalize.css/normalize.css'),
-          path.resolve(__dirname, '/node_modules/flexboxgrid/css/flexboxgrid.css'),
-          path.resolve(__dirname, '/app/static/styles/icons/icomoon.css'),
+          'node_modules/normalize.css/normalize.css',
+          'node_modules/flexboxgrid/css/flexboxgrid.css',
+          'app/static/styles/icons/icomoon.css',
         ],
         fileName: 'foundation',
       };
 
       Buildify()
+        .setDir(path.resolve(__dirname, '../'))
         .concat(foundation.files)
         .cssmin()
         .save(`${foundation.destPath}${foundation.fileName}.css`);


### PR DESCRIPTION
Buildify not resolving foundation.css path correctly on windows. Removed path.resolve from css files path and added base dir for buildify.

@rakeshmenon @vinodloha 